### PR TITLE
[FIX] - 이슈 화면 진입 시 최초에 open 상태의 이슈 데이터 로드하도록 수정

### DIFF
--- a/app/src/main/java/com/repo01/repoapp/ui/main/tab/issue/IssueFragment.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/main/tab/issue/IssueFragment.kt
@@ -43,7 +43,13 @@ class IssueFragment : Fragment() {
 
     private fun initView(){
         setFilterBar()
+        getData()
         setRecyclerView()
+    }
+
+    private fun getData(){
+        issueViewModel.updateOptionIndex(0)
+        issueViewModel.getIssues("open")
     }
 
     private fun setRecyclerView(){


### PR DESCRIPTION
- 기존 : 옵션 선택 시 데이터 로드 시작
- 수정 후 : 기본적으로 open 상태 이슈 로드