### PR TITLE
[FEAT] 검색 결과 페이징 및 소프트키보드

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     // ktx
     implementation "androidx.fragment:fragment-ktx:1.5.0"
 
+    // Paging3
+    implementation "androidx.paging:paging-runtime-ktx:3.1.1"
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,8 @@
             android:exported="false" />
         <activity
             android:name=".ui.search.SearchActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:windowSoftInputMode="stateVisible" />
         <activity
             android:name=".ui.login.LoginActivity"
             android:exported="true">

--- a/app/src/main/java/com/repo01/repoapp/data/network/SearchService.kt
+++ b/app/src/main/java/com/repo01/repoapp/data/network/SearchService.kt
@@ -9,7 +9,7 @@ interface SearchService {
     @GET("/search/repositories")
     suspend fun getSearchRepositories(
         @Query("q") query: String,
-        @Query("per_page") per_page: Int = 10,
-        @Query("page") page: Int = 1
+        @Query("per_page") per_page: Int? = 30,
+        @Query("page") page: Int? = 1
     ): Response<SearchResponse>
 }

--- a/app/src/main/java/com/repo01/repoapp/data/repository/SearchPagingSource.kt
+++ b/app/src/main/java/com/repo01/repoapp/data/repository/SearchPagingSource.kt
@@ -1,0 +1,57 @@
+package com.repo01.repoapp.data.repository
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.repo01.repoapp.data.model.SearchItemModel
+import com.repo01.repoapp.data.network.SearchService
+import com.repo01.repoapp.util.getFormattedNumber
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val STARTING_PAGING_INDEX = 1
+
+class SearchPagingSource(
+    private val service: SearchService,
+    private val query: String
+) : PagingSource<Int, SearchItemModel>() {
+
+    override fun getRefreshKey(state: PagingState<Int, SearchItemModel>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            val anchorPage = state.closestPageToPosition(anchorPosition)
+            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+        }
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, SearchItemModel> {
+        val page = params.key ?: STARTING_PAGING_INDEX
+        return try {
+            val response = withContext(Dispatchers.IO) {
+                service.getSearchRepositories(
+                    query = query,
+                    page = page,
+                    per_page = 30
+                )
+            }
+
+            val repos = response.body()?.items?.map { item ->
+                SearchItemModel(
+                    repoName = item.name,
+                    ownerName = item.owner.login,
+                    avatarUrl = item.owner.avatarUrl,
+                    description = item.description,
+                    stargazers_count = getFormattedNumber(item.stargazersCount),
+                    language = item.language
+                )
+            } ?: listOf()
+
+            LoadResult.Page(
+                data = repos,
+                prevKey = if (page == STARTING_PAGING_INDEX) null else page - 1,
+                nextKey = if (repos.isEmpty()) null else page + 1
+            )
+
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+}

--- a/app/src/main/java/com/repo01/repoapp/data/repository/SearchRepository.kt
+++ b/app/src/main/java/com/repo01/repoapp/data/repository/SearchRepository.kt
@@ -1,14 +1,19 @@
 package com.repo01.repoapp.data.repository
 
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.liveData
 import com.repo01.repoapp.data.network.SearchService
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 class SearchRepository @Inject constructor(
     private val service: SearchService
 ) {
-    suspend fun getSearchRepositories(query: String) = withContext(Dispatchers.IO) {
-        service.getSearchRepositories(query)
-    }
+    fun getSearchRepositories(query: String) = Pager(
+        config = PagingConfig(pageSize = 30),
+        pagingSourceFactory = {
+            SearchPagingSource(service = service, query = query)
+        }
+    ).liveData
+
 }

--- a/app/src/main/java/com/repo01/repoapp/ui/search/SearchActivity.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/search/SearchActivity.kt
@@ -1,14 +1,14 @@
 package com.repo01.repoapp.ui.search
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.inputmethod.InputMethodManager
 import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.DividerItemDecoration
-import androidx.recyclerview.widget.LinearLayoutManager
 import com.repo01.repoapp.R
 import com.repo01.repoapp.databinding.ActivitySearchBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -18,17 +18,22 @@ class SearchActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySearchBinding
     private val adapter by lazy { SearchItemAdapter() }
     private val viewModel: SearchViewModel by viewModels()
+    private val inputMethodManager by lazy {
+        getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_search)
-
         initViews()
         observeData()
     }
 
     private fun initViews() {
         binding.toolbar.setNavigationOnClickListener { finish() }
+        binding.clSearch.setOnClickListener {
+            binding.clSearch.requestFocus()
+        }
         initSearchEditText()
         initRecyclerView()
     }
@@ -42,9 +47,17 @@ class SearchActivity : AppCompatActivity() {
                     if (hasFocus) R.drawable.ic_variant10 else 0,
                     0
                 )
+                if (hasFocus.not()) {
+                    inputMethodManager.hideSoftInputFromWindow(this.windowToken, 0)
+                }
             }
+            requestFocus()
             doAfterTextChanged {
-                viewModel.searchRepositoriesByQuery(it.toString())
+                if (it.toString().isEmpty()) {
+                    hideSearchResultRecyclerView()
+                } else {
+                    viewModel.searchRepos(it.toString())
+                }
             }
         }
     }
@@ -56,18 +69,13 @@ class SearchActivity : AppCompatActivity() {
                     DividerItemDecoration(context, DividerItemDecoration.VERTICAL)
                 )
             }
-            layoutManager = LinearLayoutManager(context)
         }
     }
 
     private fun observeData() {
-        viewModel.searchResult.observe(this) {
-            if (it.isNotEmpty()) {
-                adapter.submitList(it)
-                showSearchResultRecyclerView()
-            } else {
-                hideSearchResultRecyclerView()
-            }
+        viewModel.result.observe(this) {
+            adapter.submitData(lifecycle, it)
+            showSearchResultRecyclerView()
         }
     }
 

--- a/app/src/main/java/com/repo01/repoapp/ui/search/SearchItemAdapter.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/search/SearchItemAdapter.kt
@@ -3,14 +3,15 @@ package com.repo01.repoapp.ui.search
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
+import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.repo01.repoapp.R
 import com.repo01.repoapp.data.model.SearchItemModel
 import com.repo01.repoapp.databinding.ItemSearchListBinding
 
-class SearchItemAdapter : ListAdapter<SearchItemModel, SearchItemAdapter.SearchItemViewHolder>(diffUtil) {
+class SearchItemAdapter :
+    PagingDataAdapter<SearchItemModel, SearchItemAdapter.SearchItemViewHolder>(diffUtil) {
 
     class SearchItemViewHolder(val binding: ItemSearchListBinding) :
         RecyclerView.ViewHolder(binding.root) {
@@ -31,7 +32,7 @@ class SearchItemAdapter : ListAdapter<SearchItemModel, SearchItemAdapter.SearchI
     }
 
     override fun onBindViewHolder(holder: SearchItemViewHolder, position: Int) {
-        holder.bind(currentList[position])
+        getItem(position)?.let { holder.bind(it) }
     }
 
     companion object {

--- a/app/src/main/java/com/repo01/repoapp/util/util.kt
+++ b/app/src/main/java/com/repo01/repoapp/util/util.kt
@@ -1,0 +1,10 @@
+package com.repo01.repoapp.util
+
+import kotlin.math.ln
+import kotlin.math.pow
+
+fun getFormattedNumber(count: Int): String {
+    if (count < 1000) return count.toString()
+    val exp = (ln(count.toDouble()) / ln(1000.0)).toInt()
+    return String.format("%.1f%c", count / 1000.0.pow(exp), "kMGTPE"[exp - 1])
+}

--- a/app/src/main/res/layout/activity_search.xml
+++ b/app/src/main/res/layout/activity_search.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_search"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@drawable/bg_main"


### PR DESCRIPTION
페이징
- Paging3 라이브러리 추가
- SearchPagingSource는 검색 결과 리스트를 받아서 화면에 보여주기 위한 모델로 변환한 뒤 반환합니다.
- SearchRepository에서는 페이징 처리된 데이터를 LiveData 형태로 받습니다.
- 뷰모델에서는 쿼리 스트링이 변할 때마다 검색을 요청합니다.

소프트 키보드
- SearchActivity의 android:windowSoftInputMode 속성을 stateVisible로 하여 소프트 키보드를 지원합니다.
- InputMethodManager를 사용해 EditText가 포커스를 잃으면 키보드를 숨기도록 했습니다.