### PR TITLE
[ADD] notifications 데이터 조회 시 페이징 기능 구현

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="$USER_HOME$/.android/avd/Pixel_2_API_32.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-07-19T17:46:24.473349Z" />
+  </component>
+</project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="$USER_HOME$/.android/avd/Pixel_2_API_32.avd" />
+            <value value="$USER_HOME$/.android/avd/Pixel_4_API_32.avd" />
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-07-19T17:46:24.473349Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-07-20T00:38:16.755273Z" />
   </component>
 </project>

--- a/app/src/main/java/com/repo01/repoapp/data/network/NotificationsService.kt
+++ b/app/src/main/java/com/repo01/repoapp/data/network/NotificationsService.kt
@@ -12,7 +12,7 @@ interface NotificationsService {
     suspend fun getNotifications(
         @Query("all") all: Boolean,
         @Query("page") page: Int,
-        @Query("per_page") per_page: Int = 8
+        @Query("per_page") per_page: Int = 10
     ): Response<List<NotificationsInfoResponse>>
 
     @PATCH("notifications/threads/{thread_id}")

--- a/app/src/main/java/com/repo01/repoapp/data/network/NotificationsService.kt
+++ b/app/src/main/java/com/repo01/repoapp/data/network/NotificationsService.kt
@@ -11,8 +11,8 @@ interface NotificationsService {
     @GET("notifications")
     suspend fun getNotifications(
         @Query("all") all: Boolean,
-        @Query("per_page") per_page: Int = 10,
-        @Query("page") page: Int = 1
+        @Query("page") page: Int,
+        @Query("per_page") per_page: Int = 8
     ): Response<List<NotificationsInfoResponse>>
 
     @PATCH("notifications/threads/{thread_id}")

--- a/app/src/main/java/com/repo01/repoapp/data/repository/NotificationsRepository.kt
+++ b/app/src/main/java/com/repo01/repoapp/data/repository/NotificationsRepository.kt
@@ -8,9 +8,9 @@ import javax.inject.Inject
 class NotificationsRepository @Inject constructor(private val notificationsService: NotificationsService) {
     suspend fun readNotification(threadId: Long) = notificationsService.readNotifications(threadId)
 
-    suspend fun getNotifications(all: Boolean): UiState<List<NotificationsInfoModel>> {
+    suspend fun getNotifications(all: Boolean, page: Int): UiState<List<NotificationsInfoModel>> {
         runCatching {
-            notificationsService.getNotifications(all)
+            notificationsService.getNotifications(all, page)
         }.onSuccess { response ->
             return if (response.body() == null) {
                 UiState.Error("Load Notifications Data Error")

--- a/app/src/main/java/com/repo01/repoapp/data/repository/NotificationsRepository.kt
+++ b/app/src/main/java/com/repo01/repoapp/data/repository/NotificationsRepository.kt
@@ -6,10 +6,9 @@ import com.repo01.repoapp.ui.common.UiState
 import javax.inject.Inject
 
 class NotificationsRepository @Inject constructor(private val notificationsService: NotificationsService) {
-    suspend fun getNotifications(all: Boolean) = notificationsService.getNotifications(all)
     suspend fun readNotification(threadId: Long) = notificationsService.readNotifications(threadId)
 
-    suspend fun getNotificationsRefactor(all: Boolean): UiState<List<NotificationsInfoModel>> {
+    suspend fun getNotifications(all: Boolean): UiState<List<NotificationsInfoModel>> {
         runCatching {
             notificationsService.getNotifications(all)
         }.onSuccess { response ->

--- a/app/src/main/java/com/repo01/repoapp/data/repository/NotificationsRepository.kt
+++ b/app/src/main/java/com/repo01/repoapp/data/repository/NotificationsRepository.kt
@@ -1,9 +1,29 @@
 package com.repo01.repoapp.data.repository
 
+import com.repo01.repoapp.data.model.NotificationsInfoModel
 import com.repo01.repoapp.data.network.NotificationsService
+import com.repo01.repoapp.ui.common.UiState
 import javax.inject.Inject
 
 class NotificationsRepository @Inject constructor(private val notificationsService: NotificationsService) {
     suspend fun getNotifications(all: Boolean) = notificationsService.getNotifications(all)
     suspend fun readNotification(threadId: Long) = notificationsService.readNotifications(threadId)
+
+    suspend fun getNotificationsRefactor(all: Boolean): UiState<List<NotificationsInfoModel>> {
+        runCatching {
+            notificationsService.getNotifications(all)
+        }.onSuccess { response ->
+            return if (response.body() == null) {
+                UiState.Error("Load Notifications Data Error")
+            } else {
+                UiState.Success(response.body()!!.map { notificationsInfoResponse ->
+                    notificationsInfoResponse.mapNotificationsMoedel()
+                })
+            }
+        }.onFailure { e ->
+            return UiState.Error(e.message)
+        }
+        return UiState.Error("runCatching Error")
+    }
+
 }

--- a/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsFragment.kt
@@ -64,16 +64,35 @@ class NotificationsFragment : Fragment(), ItemTouchHelperListener {
                 override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                     super.onScrolled(recyclerView, dx, dy)
 
+                    val layoutManager = binding.rvNotificationsList.layoutManager
+                    PrintLog.printLog("현재 보이는 마지막 : ${(layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()}")
+
                     if (!binding.rvNotificationsList.canScrollVertically(1)) {
                         PrintLog.printLog("스크롤 최하단 도착")
+
+                        val lastVisibleItemPosition = (layoutManager as LinearLayoutManager).findLastCompletelyVisibleItemPosition()
+                        if(lastVisibleItemPosition == notificationsAdpater.itemCount - 1) {
+                            if (notificationsViewModel.notificationState.value != UiState.Loading
+                                && notificationsViewModel.addtionalNotificationState != UiState.Loading
+                            ) {
+                                notificationsViewModel.getNotifications(
+                                    false,
+                                    notificationsViewModel.currentPage
+                                )
+                                PrintLog.printLog("${notificationsViewModel.currentPage} page 호출!")
+                            }
+                        }
                     }
                 }
             })
+
+            // 페이지 당 로드 데이터 개수 10개로 하는 경우에만 다다음 페이지까지 바로 호출하게 됨 -> 테스트 필요
+            // 8 로 설정해둔 상태
         }
     }
 
     private fun getNotificationsData() {
-        notificationsViewModel.getNotifications(false)
+        notificationsViewModel.getNotifications(false, notificationsViewModel.currentPage)
     }
 
     private fun observeData() {

--- a/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsFragment.kt
@@ -94,11 +94,9 @@ class NotificationsFragment : Fragment(), ItemTouchHelperListener {
                         if (lastVisibleItemPosition == notificationsAdpater.itemCount - 1) {
                             if (notificationsViewModel.addtionalNotificationState != UiState.Loading &&
                                 notificationsViewModel.notificationState.value != UiState.Loading &&
-                                !notificationsViewModel.testFlag &&
                                 isFirstTimeCall
 
                             ) {
-                                notificationsViewModel.testFlag = true
                                 notificationsViewModel.getNotifications(
                                     false,
                                     notificationsViewModel.currentPage
@@ -124,8 +122,6 @@ class NotificationsFragment : Fragment(), ItemTouchHelperListener {
     private fun observeNotificationsData() {
         notificationsViewModel.notificationList.observe(viewLifecycleOwner) {
             notificationsAdpater.submitList(it.toList())
-
-            notificationsViewModel.testFlag = false
         }
 
         notificationsViewModel.notificationState.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsFragment.kt
@@ -97,10 +97,7 @@ class NotificationsFragment : Fragment(), ItemTouchHelperListener {
                                 isFirstTimeCall
 
                             ) {
-                                notificationsViewModel.getNotifications(
-                                    false,
-                                    notificationsViewModel.currentPage
-                                )
+                                notificationsViewModel.getNotifications(false)
                                 PrintLog.printLog("${notificationsViewModel.currentPage} page 호출!")
                             }
                         }
@@ -111,7 +108,7 @@ class NotificationsFragment : Fragment(), ItemTouchHelperListener {
     }
 
     private fun getNotificationsData() {
-        notificationsViewModel.getNotifications(false, notificationsViewModel.currentPage)
+        notificationsViewModel.getNotifications(false)
     }
 
     private fun observeData() {

--- a/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsFragment.kt
@@ -73,8 +73,7 @@ class NotificationsFragment : Fragment(), ItemTouchHelperListener {
     }
 
     private fun getNotificationsData() {
-        //notificationsViewModel.getNotifications()
-        notificationsViewModel.getNotificationsRefactor(false)
+        notificationsViewModel.getNotifications(false)
     }
 
     private fun observeData() {

--- a/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsViewModel.kt
@@ -21,8 +21,7 @@ import javax.inject.Inject
 @HiltViewModel
 class NotificationsViewModel @Inject constructor(
     private val issueRepository: IssueRepository,
-    private val notificationsRepository: NotificationsRepository,
-    private val organizationRepository: OrganizationRepository
+    private val notificationsRepository: NotificationsRepository
 ) : ViewModel() {
 
     private val _notificationList = MutableLiveData<List<NotificationsItemModel>>()
@@ -39,10 +38,10 @@ class NotificationsViewModel @Inject constructor(
     var addtionalNotificationState: UiState<Any> = UiState.Empty
 
 
-    fun getNotifications(all: Boolean, page: Int) {
+    fun getNotifications(all: Boolean) {
         _notificationState.value = UiState.Loading
         viewModelScope.launch {
-            _notificationState.value = notificationsRepository.getNotifications(all, page)
+            _notificationState.value = notificationsRepository.getNotifications(all, currentPage)
         }
     }
 

--- a/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsViewModel.kt
@@ -38,6 +38,8 @@ class NotificationsViewModel @Inject constructor(
     var currentPage = 1
     var addtionalNotificationState: UiState<Any> = UiState.Empty
 
+    var testFlag = false
+
     fun getNotifications(all: Boolean, page: Int) {
         _notificationState.value = UiState.Loading
         viewModelScope.launch {
@@ -93,6 +95,7 @@ class NotificationsViewModel @Inject constructor(
             setProgressBarVisibility(false)
             addtionalNotificationState = UiState.Success(Any())
             if(resultList.isNotEmpty()) currentPage++
+
             // 추가 api 호출 시 에러 처리 필요
         }
     }

--- a/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsViewModel.kt
@@ -38,7 +38,6 @@ class NotificationsViewModel @Inject constructor(
     var currentPage = 1
     var addtionalNotificationState: UiState<Any> = UiState.Empty
 
-    var testFlag = false
 
     fun getNotifications(all: Boolean, page: Int) {
         _notificationState.value = UiState.Loading

--- a/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.repo01.repoapp.data.model.IssueItemModel
 import com.repo01.repoapp.data.model.NotificationsInfoModel
 import com.repo01.repoapp.data.model.NotificationsItemModel
 import com.repo01.repoapp.data.repository.IssueRepository
@@ -34,10 +33,10 @@ class NotificationsViewModel @Inject constructor(
     private val _notificationState = MutableLiveData<UiState<List<NotificationsInfoModel>>>()
     val notificationState: LiveData<UiState<List<NotificationsInfoModel>>> = _notificationState
 
-    fun getNotificationsRefactor(all: Boolean) {
+    fun getNotifications(all: Boolean) {
         _notificationState.value = UiState.Loading
         viewModelScope.launch {
-            _notificationState.value = notificationsRepository.getNotificationsRefactor(all)
+            _notificationState.value = notificationsRepository.getNotifications(all)
         }
     }
 


### PR DESCRIPTION
- 추후 삭제 기능 후 데이터 갱신을 생각해 Paing3 대신 리사이클러뷰에 ScrollListener를 추가하는 방식으로 구현했습니다
- 기존에 다음페이지 요청시 다다음 페이지까지 연속으로 자동 호출 되는 부분을 해결했습니다
  - Scroll State 리스너를 추가해 마지막 아이템에 도달하면서 SCROLL_STATE_IDLE 로 스크롤 상태가 바뀌는 순간 딱 한번 다음 페이지 요청을 할 수 있도록 수정했습니다