### PR TITLE
[FEAT] #12 #13 - 알림 데이터 스와이프 시 읽음 처리 및 데이터 갱신

### DIFF
--- a/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsFragment.kt
@@ -95,7 +95,6 @@ class NotificationsFragment : Fragment(), ItemTouchHelperListener {
                             if (notificationsViewModel.addtionalNotificationState != UiState.Loading &&
                                 notificationsViewModel.notificationState.value != UiState.Loading &&
                                 isFirstTimeCall
-
                             ) {
                                 notificationsViewModel.getNotifications(false)
                                 PrintLog.printLog("${notificationsViewModel.currentPage} page 호출!")
@@ -151,6 +150,15 @@ class NotificationsFragment : Fragment(), ItemTouchHelperListener {
     override fun itemSwipe(position: Int) {
         // TODO - position의 id 값으로 읽음 처리 하기
         val threadId = notificationsAdpater.currentList[position].id
+
+        val itemPage = position / 10 + 1
+        PrintLog.printLog("item position : $position")
+        PrintLog.printLog("item page : $itemPage")
+
+        notificationsViewModel.currentPage = itemPage
+        notificationsViewModel.deleteItem(position)
+        notificationsViewModel.deleteDataForUpdate()
+
         notificationsViewModel.readNotification(threadId.toLong())
     }
 }

--- a/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsViewModel.kt
@@ -108,10 +108,25 @@ class NotificationsViewModel @Inject constructor(
             else{
                 PrintLog.printLog("read error")
             }
+            getNotifications(false) // 읽음 처리 후 해당 아이템의 페이지부터 다시 데이터 로드
         }
     }
 
     fun setProgressBarVisibility(isVisible: Boolean){
         _progressBarVisible.value = isVisible
+    }
+
+    fun deleteItem(position: Int){
+        notificationListForUpdate.removeAt(position)
+        _notificationList.value = notificationListForUpdate
+    }
+
+    fun deleteDataForUpdate(){
+        val deleteStartInx = (currentPage - 1) * 10
+        var inx = notificationListForUpdate.size - 1
+        while(inx >= deleteStartInx){
+            notificationListForUpdate.removeLast()
+            inx--
+        }
     }
 }

--- a/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/main/tab/notifications/NotificationsViewModel.kt
@@ -25,7 +25,7 @@ class NotificationsViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val _notificationList = MutableLiveData<List<NotificationsItemModel>>()
-    private val notificationListForUpdate = mutableListOf<NotificationsItemModel>()
+    private var notificationListForUpdate = mutableListOf<NotificationsItemModel>()
     val notificationList: LiveData<List<NotificationsItemModel>> = _notificationList
 
     private val _progressBarVisible = MutableLiveData<Boolean>()
@@ -123,10 +123,6 @@ class NotificationsViewModel @Inject constructor(
 
     fun deleteDataForUpdate(){
         val deleteStartInx = (currentPage - 1) * 10
-        var inx = notificationListForUpdate.size - 1
-        while(inx >= deleteStartInx){
-            notificationListForUpdate.removeLast()
-            inx--
-        }
+        notificationListForUpdate = notificationListForUpdate.subList(0, deleteStartInx)
     }
 }


### PR DESCRIPTION
- 스와이프 한 아이템이 몇 페이지에 위치한 데이터인지 구합니다
- 현재 리사이클러뷰에 사용되는 데이터 리스트에서 위에서 구한 페이지에 해당하는 부분부터 마지막까지 모두 데이터를 지웁니다
- 위에서 구한 페이지로 새로 10개의 데이터를 로드 후 데이터 리스트에 이어 붙입니다
- 갱신된 리스트로 리사이클러뷰를 업데이트 합니다