### PR TITLE
[FEAT] #9 - 이슈 데이터 페이징 구현

### DIFF
--- a/app/src/main/java/com/repo01/repoapp/data/network/IssueService.kt
+++ b/app/src/main/java/com/repo01/repoapp/data/network/IssueService.kt
@@ -11,8 +11,8 @@ interface IssueService {
     @GET("user/issues")
     suspend fun getIssues(
         @Query("state") state: String,
-        @Query("per_page") per_page: Int = 10,
-        @Query("page") page: Int = 1
+        @Query("page") page: Int,
+        @Query("per_page") per_page: Int = 10
     ): Response<List<IssueResponse>>
 
     @GET("repos/{owner}/{repo}/issues/{issue_number}")

--- a/app/src/main/java/com/repo01/repoapp/data/repository/IssueRepository.kt
+++ b/app/src/main/java/com/repo01/repoapp/data/repository/IssueRepository.kt
@@ -9,9 +9,9 @@ class IssueRepository @Inject constructor(private val issueService: IssueService
     suspend fun getSpecificIssue(owner: String, repo: String, issueNumber: Int) =
         issueService.getSpecificIssue(owner, repo, issueNumber)
 
-    suspend fun getIssues(state: String): UiState<List<IssueItemModel>> {
+    suspend fun getIssues(state: String, page: Int): UiState<List<IssueItemModel>> {
         runCatching {
-            issueService.getIssues(state)
+            issueService.getIssues(state, page)
         }.onSuccess { response ->
             return if (response.body() == null) {
                 UiState.Error("Load Issue Data Error")

--- a/app/src/main/java/com/repo01/repoapp/ui/main/tab/issue/IssueViewModel.kt
+++ b/app/src/main/java/com/repo01/repoapp/ui/main/tab/issue/IssueViewModel.kt
@@ -20,15 +20,27 @@ class IssueViewModel @Inject constructor(private val issueRepository: IssueRepos
 
     private val _issueState = MutableLiveData<UiState<List<IssueItemModel>>>()
     val issueState: LiveData<UiState<List<IssueItemModel>>> = _issueState
+    val issueListForUpdate = mutableListOf<IssueItemModel>()
+
+    var currentPage = 1
+    var currentState = "open"
 
     fun updateOptionIndex(inx: Int) {
         _optionIndex.value = inx
     }
 
-    fun getIssues(state: String) {
+    fun getIssues() {
         _issueState.value = UiState.Loading
         viewModelScope.launch {
-            _issueState.value = issueRepository.getIssues(state)
+            _issueState.value = issueRepository.getIssues(currentState, currentPage)
         }
+    }
+
+    fun resetPage(){
+        currentPage = 1
+    }
+
+    fun clearIssueListForUpdate(){
+        issueListForUpdate.clear()
     }
 }

--- a/app/src/main/res/layout/fragment_issue.xml
+++ b/app/src/main/res/layout/fragment_issue.xml
@@ -97,5 +97,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/cl_filter_bar" />
 
+        <ProgressBar
+            android:id="@+id/pb_loading"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:indeterminateTint="@color/white" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
- 노티피케이션 데이터 페이징과 동일한 방법으로 구현했습니다
- 리사이클러뷰 스크롤리스너를 활용했습니다