### PR TITLE
[FIX] #58 - 메인액티비티 탭 레이아웃 아이템 크기 수정

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -84,6 +84,8 @@
             app:layout_constraintTop_toBottomOf="@id/cl_top_bar"
             app:tabIndicatorHeight="0dp"
             app:tabMode="fixed"
+            app:tabMaxWidth="0dp"
+            app:tabGravity="fill"
             app:tabRippleColor="@null" />
 
         <androidx.viewpager2.widget.ViewPager2


### PR DESCRIPTION
app:tabMaxWidth="0dp"
app:tabGravity="fill"
app:tabMode="fixed"

위 속성을 활용해 화면 가로에 따라 각 탭이 꽉차게 나오도록 수정했습니다